### PR TITLE
Use SameSite=Lax cookies

### DIFF
--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -5,7 +5,7 @@ enable_gzip = true
 
 [security]
 cookie_secure = true
-cookie_samesite = strict
+cookie_samesite = lax
 disable_gravatar = true
 data_source_proxy_whitelist = ghss-influxdb
 x_content_type_options = true

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -133,7 +133,7 @@ async fn setup_authorized_route(
             .header(
                 "set-cookie",
                 format!(
-                    "token={}; Path=/; SameSite=Strict; Secure; HttpOnly",
+                    "token={}; Path=/; SameSite=Lax; Secure; HttpOnly",
                     token.access_token
                 ),
             )
@@ -220,7 +220,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and(warp::path!("favicon.ico"))
         .and(warp::fs::file("static/favicon.ico"));
 
-    let dashboard_login = warp::path!("_" / "login" / ..)
+    let dashboard_login = warp::path!("_" / "login")
         .and(raw_request())
         .and(warp::cookie::optional("token"))
         .and_then(dashboard_login_route);


### PR DESCRIPTION
When we make the login flow through GitHub the request to / is initiated by GitHub. This means with SameSite=Strict the browser will not send the cookie. It seems to be that SameSite=Lax is the appropriate setting here.

Fixes #6 